### PR TITLE
Don't emit invalid json on missing fields

### DIFF
--- a/src/layer/mod.rs
+++ b/src/layer/mod.rs
@@ -897,10 +897,10 @@ where
         self.keyed_values.insert(
             SchemaKey::from(key.into()),
             JsonValue::DynamicRawFromEvent(Box::new(|event, writer| {
-                event
-                    .metadata()
-                    .file()
-                    .map_or(Ok(()), |file| write_escaped(writer, file))
+                match event.metadata().file() {
+                    Some(file) => write_escaped(writer, file),
+                    None => write!(writer, "null"),
+                }
             })),
         );
         self
@@ -914,10 +914,10 @@ where
         self.keyed_values.insert(
             SchemaKey::from(key.into()),
             JsonValue::DynamicRawFromEvent(Box::new(|event, writer| {
-                event
-                    .metadata()
-                    .line()
-                    .map_or(Ok(()), |line| write!(writer, "{line}"))
+                match event.metadata().line() {
+                    Some(line) => write!(writer, "{line}"),
+                    None => write!(writer, "null"),
+                }
             })),
         );
         self
@@ -942,9 +942,10 @@ where
         self.keyed_values.insert(
             SchemaKey::from(key.into()),
             JsonValue::DynamicRawFromEvent(Box::new(|_event, writer| {
-                std::thread::current()
-                    .name()
-                    .map_or(Ok(()), |name| write_escaped(writer, name))
+                match std::thread::current().name() {
+                    Some(name) => write_escaped(writer, name),
+                    None => write!(writer, "null"),
+                }
             })),
         );
         self


### PR DESCRIPTION
Sample invalid log with `.with_line_number(true)` and `tracing-log` feature:
```
{
  "level": "INFO",
  "target": "log",
  "line_number":,
  "timestamp": "2024-12-02T20:53:51.900774Z",
  "log.file": "/home/gabriel_bastos/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rocket-0.5.0/src/server.rs",
  "log.line": 327,
  "log.module_path": "rocket::server",
  "log.target": "rocket::server::_",
  "message": "Matched: (read) POST /v1/auth/read"
}
```

Notice the `  "line_number":,` part.