### PR TITLE
fix: correctly turn on optional opentelemetry dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ opentelemetry-0-27 = { package = "opentelemetry", version = "0.27.0", default-fe
 tracing-opentelemetry-0-29 = { package = "tracing-opentelemetry", version = "0.29.0", default-features = false, optional = true }
 opentelemetry-0-28 = { package = "opentelemetry", version = "0.28.0", default-features = false, optional = true }
 tracing-opentelemetry-0-30 = { package = "tracing-opentelemetry", version = "0.30.0", default-features = false, optional = true }
-opentelemetry-0-29 = { package = "opentelemetry", version = "0.29.0", default-features = false, optional = true }
+opentelemetry-0-29 = { package = "opentelemetry", version = "0.29.0", default-features = false, features = ["futures"], optional = true }
 tracing-opentelemetry-0-31 = { package = "tracing-opentelemetry", version = "0.31.0", default-features = false, optional = true }
 opentelemetry-0-30 = { package = "opentelemetry", version = "0.30.0", default-features = false, optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,20 @@ tracing-opentelemetry-0-29 = [
     "dep:tracing-opentelemetry-0-29",
     "dep:opentelemetry-0-28",
 ]
+tracing-opentelemetry-0-30 = [
+    "dep:tracing-opentelemetry-0-30",
+    "dep:opentelemetry-0-29",
+]
+tracing-opentelemetry-0-31 = [
+    "dep:tracing-opentelemetry-0-31",
+    "dep:opentelemetry-0-30",
+]
+
+# TODO Remove this for the next breaking release.
+# This is the price I have to pay to the gods of semantic versioning for failing to notice I created
+# unintended implicit features.
+opentelemetry-0-29 = ["dep:opentelemetry-0-29"]
+opentelemetry-0-30 = ["dep:opentelemetry-0-30"]
 
 # Required for intra-doc links to resolve correctly
 __private_docs = ["tracing-subscriber/time", "tracing-subscriber/local-time"]


### PR DESCRIPTION
## Motivation

Newer opentelemetry features were wrong as they did not enable all needed dependencies causing compilation failures.

Closes #24 

## Solution

Correctly enable all needed dependencies.

Also, create new features for the implicit features that were mistakenly added. This is needed in case someone found the bug and simply worked around it by enabling these features so that we do not break them in a patch release. These are to be deleted with then next breaking changes.