### PR TITLE
bench: update benchmarks and add operation-specific benchmarks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
     - name: Run tests
       run: |
         cargo update -p regex --precise 1.5.3
-        cargo +${{ env.MSRV }} test --workspace --all-features --all-targets --locked
+        cargo +${{ env.MSRV }} test --workspace --all-features --lib --examples --tests --locked
 
   deny-check:
     name: cargo-deny check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,19 +291,19 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -372,9 +372,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "log"
@@ -403,7 +403,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1248,16 +1248,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ dependencies = [
  "futures-util",
  "opentelemetry 0.29.1",
  "percent-encoding",
- "rand 0.9.1",
+ "rand 0.9.4",
  "thiserror 2.0.11",
 ]
 
@@ -609,7 +609,7 @@ dependencies = [
  "futures-util",
  "opentelemetry 0.30.0",
  "percent-encoding",
- "rand 0.9.1",
+ "rand 0.9.4",
  "serde_json",
  "thiserror 2.0.11",
 ]
@@ -684,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ lazy_static = { version = "1.1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", default-features = false }
+
 snafu = "0.6.10"
 thiserror = "1.0.31"
 tracing = { version = "0.1", features = ["attributes"] }
@@ -100,6 +101,10 @@ bench = false
 
 [[bench]]
 name = "tracing_subscriber"
+harness = false
+
+[[bench]]
+name = "operations"
 harness = false
 
 [lints.rust]

--- a/benches/operations.rs
+++ b/benches/operations.rs
@@ -1,0 +1,248 @@
+use std::{any::Any, hint::black_box, io::sink};
+
+use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion, Throughput};
+use tracing::Dispatch;
+
+mod support;
+
+struct BenchSetup {
+    name: &'static str,
+    #[expect(clippy::type_complexity)]
+    operation: Box<dyn FnMut(&mut Bencher<'_>, &usize)>,
+}
+
+fn make_dispatch(current_span: bool, span_list: bool) -> tracing::Dispatch {
+    let collector = json_subscriber::fmt::Subscriber::builder()
+        .with_writer(sink)
+        .with_current_span(current_span)
+        .with_span_list(span_list)
+        .finish();
+    tracing::Dispatch::new(collector)
+}
+
+fn create_span_with_fields(n: usize) -> tracing::Span {
+    tracing::info_span!(
+        "span",
+        n,
+        text = "lorem ipsum",
+        number = 42,
+        float = 4.2,
+        detail = debug([0, 1, 2])
+    )
+}
+
+fn nested_entered_spans(depth: usize) -> Vec<tracing::span::EnteredSpan> {
+    let mut guards = Vec::with_capacity(depth);
+    for level in 0..depth {
+        guards.push(create_span_with_fields(level).entered());
+    }
+    guards
+}
+
+fn bench_operations(criterion: &mut Criterion) {
+    fn run_bench(
+        bencher: &mut Bencher,
+        input: usize,
+        dispatch: &Dispatch,
+        setup: impl Fn(usize) -> Box<dyn Any>,
+        operation: impl Fn(usize),
+    ) {
+        tracing::dispatcher::with_default(dispatch, || {
+            let _setup = setup(input);
+            bencher.iter(|| {
+                operation(black_box(input));
+            })
+        });
+    }
+
+    fn prepare_bench(
+        setup: impl Fn(usize) -> Box<dyn Any> + Clone + 'static,
+        operation: impl Fn(usize) + Clone + 'static,
+    ) -> [BenchSetup; 4] {
+        [
+            BenchSetup {
+                name: "no_span_output",
+                operation: Box::new({
+                    let operation = operation.clone();
+                    let setup = setup.clone();
+                    move |bencher, &input| {
+                        run_bench(
+                            bencher,
+                            input,
+                            &make_dispatch(false, false),
+                            setup.clone(),
+                            operation.clone(),
+                        );
+                    }
+                }),
+            },
+            BenchSetup {
+                name: "current_span",
+                operation: Box::new({
+                    let operation = operation.clone();
+                    let setup = setup.clone();
+                    move |bencher, &input| {
+                        run_bench(
+                            bencher,
+                            input,
+                            &make_dispatch(true, false),
+                            setup.clone(),
+                            operation.clone(),
+                        );
+                    }
+                }),
+            },
+            BenchSetup {
+                name: "span_list",
+                operation: Box::new({
+                    let operation = operation.clone();
+                    let setup = setup.clone();
+                    move |bencher, &input| {
+                        run_bench(
+                            bencher,
+                            input,
+                            &make_dispatch(false, true),
+                            setup.clone(),
+                            operation.clone(),
+                        );
+                    }
+                }),
+            },
+            BenchSetup {
+                name: "current_span_and_span_list",
+                operation: Box::new({
+                    let operation = operation.clone();
+                    let setup = setup.clone();
+                    move |bencher, &input| {
+                        run_bench(
+                            bencher,
+                            input,
+                            &make_dispatch(true, true),
+                            setup.clone(),
+                            operation.clone(),
+                        );
+                    }
+                }),
+            },
+        ]
+    }
+
+    bench_throughput_group(
+        criterion,
+        "new_span",
+        [100],
+        prepare_bench(
+            |_| Box::new(()),
+            |n| {
+                for _ in 0..n {
+                    black_box(create_span_with_fields(black_box(n)));
+                }
+            },
+        ),
+    );
+
+    bench_throughput_group(
+        criterion,
+        "event_at_root",
+        [100],
+        prepare_bench(
+            |_| Box::new(()),
+            |n| {
+                for _ in 0..n {
+                    tracing::info!(
+                        text = black_box("lorem ipsum"),
+                        number = black_box(42),
+                        float = black_box(4.2),
+                        detail = black_box(debug([0, 1, 2])),
+                        "hello"
+                    );
+                }
+            },
+        ),
+    );
+
+    bench_throughput_group(
+        criterion,
+        "event_in_span",
+        [1, 10, 100],
+        prepare_bench(
+            |n| Box::new(create_span_with_fields(n).entered()),
+            |n| {
+                for _ in 0..n {
+                    tracing::info!("Hello");
+                }
+            },
+        ),
+    );
+
+    // Input is parent-span depth, not work units, so throughput-as-elements would
+    // misreport. Use the plain group helper so criterion just plots time vs. depth.
+    bench_input_group(
+        criterion,
+        "event_in_nested_span",
+        [1, 5, 25],
+        prepare_bench(
+            |depth| Box::new(nested_entered_spans(depth)),
+            |_| {
+                tracing::info!("Hello");
+            },
+        ),
+    );
+
+    bench_throughput_group(
+        criterion,
+        "record_value_in_span",
+        [1, 10, 100],
+        prepare_bench(
+            |n| Box::new(create_span_with_fields(n).entered()),
+            |n| {
+                let span = tracing::Span::current();
+                for _ in 0..n {
+                    span.record("n", black_box(n));
+                }
+            },
+        ),
+    );
+}
+
+fn bench_input_group<const INPUTS: usize, const COUNT: usize>(
+    c: &mut Criterion,
+    group_name: &'static str,
+    inputs: [usize; INPUTS],
+    mut benches: [BenchSetup; COUNT],
+) {
+    let mut group = c.benchmark_group(group_name);
+    for input in inputs {
+        for bench_setup in &mut benches {
+            group.bench_with_input(
+                BenchmarkId::new(bench_setup.name, input),
+                &input,
+                &mut bench_setup.operation,
+            );
+        }
+    }
+    group.finish();
+}
+
+fn bench_throughput_group<const INPUTS: usize, const COUNT: usize>(
+    c: &mut Criterion,
+    group_name: &'static str,
+    inputs: [usize; INPUTS],
+    mut benches: [BenchSetup; COUNT],
+) {
+    let mut group = c.benchmark_group(group_name);
+    for input in inputs {
+        group.throughput(Throughput::Elements(input as u64));
+        for bench_setup in &mut benches {
+            group.bench_with_input(
+                BenchmarkId::new(bench_setup.name, input),
+                &input,
+                &mut bench_setup.operation,
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_operations);
+criterion_main!(benches);

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -4,7 +4,28 @@ use std::{
     time::{Duration, Instant},
 };
 
+use criterion::{Criterion, Throughput};
 use tracing::Dispatch;
+
+type Group<'a> = criterion::BenchmarkGroup<'a, criterion::measurement::WallTime>;
+#[allow(
+    dead_code,
+    reason = "This is used from benches, just the module tree is confused."
+)]
+pub(super) fn bench_thrpt(
+    c: &mut Criterion,
+    name: &'static str,
+    mut f: impl FnMut(&mut Group<'_>, &usize),
+) {
+    const N_SPANS: &[usize] = &[1, 10, 50];
+
+    let mut group = c.benchmark_group(name);
+    for spans in N_SPANS {
+        group.throughput(Throughput::Elements(*spans as u64));
+        f(&mut group, spans);
+    }
+    group.finish();
+}
 
 #[derive(Clone)]
 pub(super) struct MultithreadedBench {

--- a/benches/tracing_subscriber.rs
+++ b/benches/tracing_subscriber.rs
@@ -1,9 +1,9 @@
 use std::{io::sink, time::Duration};
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 mod support;
-use support::MultithreadedBench;
+use support::{bench_thrpt, MultithreadedBench};
 
 fn mk_dispatch() -> tracing::Dispatch {
     #[cfg(not(bench_tracing_baseline))]
@@ -79,18 +79,6 @@ fn bench_new_span(c: &mut Criterion) {
             })
         });
     });
-}
-
-type Group<'a> = criterion::BenchmarkGroup<'a, criterion::measurement::WallTime>;
-fn bench_thrpt(c: &mut Criterion, name: &'static str, mut f: impl FnMut(&mut Group<'_>, &usize)) {
-    const N_SPANS: &[usize] = &[1, 10, 50];
-
-    let mut group = c.benchmark_group(name);
-    for spans in N_SPANS {
-        group.throughput(Throughput::Elements(*spans as u64));
-        f(&mut group, spans);
-    }
-    group.finish();
 }
 
 fn bench_event(c: &mut Criterion) {


### PR DESCRIPTION
Improve benchmarks to better measure `json-subscriber` operations.