### PR TITLE
Fix docs.rs build after doc_auto_cfg removal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@
 //! }
 //! ```
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(clippy::pedantic)]
 #![allow(clippy::struct_excessive_bools)]
 #![allow(clippy::module_name_repetitions)]


### PR DESCRIPTION
## Motivation
Fix the failing docs.rs build after `doc_auto_cfg` was removed.

## Solution
Use `doc_cfg`, which now includes `doc_auto_cfg`.

Closes #38 