### PR TITLE
perf: write event JSON directly into the output buffer

### DIFF
--- a/src/cached.rs
+++ b/src/cached.rs
@@ -2,5 +2,4 @@ use std::sync::Arc;
 
 pub(crate) enum Cached {
     Raw(Arc<str>),
-    Array(Vec<Arc<str>>),
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,19 +1,14 @@
 use std::{
     cell::{RefCell, RefMut},
-    io,
+    fmt, io,
 };
 
-pub(crate) struct Cursor<'buf>(RefCell<&'buf mut String>);
+pub(crate) struct Cursor<'buf>(RefCell<&'buf mut Vec<u8>>);
 
 impl io::Write for &Cursor<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let mut inner = self.0.borrow_mut();
-        let s =
-            std::str::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-
-        inner.push_str(s);
-
-        Ok(s.len())
+        self.0.borrow_mut().extend_from_slice(buf);
+        Ok(buf.len())
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -22,11 +17,20 @@ impl io::Write for &Cursor<'_> {
 }
 
 impl<'buf> Cursor<'buf> {
-    pub fn new(inner: &'buf mut String) -> Self {
+    pub fn new(inner: &'buf mut Vec<u8>) -> Self {
         Self(RefCell::new(inner))
     }
 
-    pub fn inner_mut(&self) -> RefMut<'_, &'buf mut String> {
+    pub fn inner_mut(&self) -> RefMut<'_, &'buf mut Vec<u8>> {
         self.0.borrow_mut()
+    }
+}
+
+pub(crate) struct FmtWrite<'a>(pub(crate) &'a mut Vec<u8>);
+
+impl fmt::Write for FmtWrite<'_> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.0.extend_from_slice(s.as_bytes());
+        Ok(())
     }
 }

--- a/src/field_writer.rs
+++ b/src/field_writer.rs
@@ -1,5 +1,3 @@
-use crate::cursor::Cursor;
-
 /// A writer passed to closures registered with
 /// [`add_multiple_dynamic_fields`](crate::JsonLayer::add_multiple_dynamic_fields).
 ///
@@ -7,13 +5,19 @@ use crate::cursor::Cursor;
 /// output. Keys are `&str` (no allocation required for static strings), and values accept any
 /// type that implements [`serde::Serialize`].
 pub struct FieldWriter<'a> {
-    writer: &'a mut String,
+    writer: &'a mut Vec<u8>,
     prefix_comma: bool,
     wrote_anything: bool,
 }
 
+pub(crate) fn write_json_key(writer: &mut Vec<u8>, key: &str) -> serde_json::Result<()> {
+    serde_json::to_writer(&mut *writer, key)?;
+    writer.push(b':');
+    Ok(())
+}
+
 impl<'a> FieldWriter<'a> {
-    pub(crate) fn new(writer: &'a mut String, prefix_comma: bool) -> Self {
+    pub(crate) fn new(writer: &'a mut Vec<u8>, prefix_comma: bool) -> Self {
         Self {
             writer,
             prefix_comma,
@@ -48,17 +52,15 @@ impl<'a> FieldWriter<'a> {
         let rollback = self.writer.len();
 
         if self.wrote_anything || self.prefix_comma {
-            self.writer.push(',');
+            self.writer.push(b',');
         }
 
-        if let Err(error) = serde_json::to_writer(&Cursor::new(self.writer), key) {
+        if let Err(error) = write_json_key(self.writer, key) {
             self.writer.truncate(rollback);
             return Err(error);
         }
 
-        self.writer.push(':');
-
-        if let Err(error) = serde_json::to_writer(&Cursor::new(self.writer), &value) {
+        if let Err(error) = serde_json::to_writer(&mut *self.writer, &value) {
             self.writer.truncate(rollback);
             return Err(error);
         }

--- a/src/layer/event.rs
+++ b/src/layer/event.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::{
 use crate::{
     cached::Cached,
     cursor::Cursor,
-    field_writer::FieldWriter,
+    field_writer::{write_json_key, FieldWriter},
     layer::{JsonLayer, JsonValue, SchemaKey},
     serde::JsonSubscriberFormatter,
 };
@@ -71,7 +71,7 @@ where
     pub(crate) fn format_event(
         &self,
         context: &Context<'_, S>,
-        writer: &mut String,
+        writer: &mut Vec<u8>,
         event: &Event<'_>,
     ) -> fmt::Result {
         let mut visit = || {
@@ -100,7 +100,7 @@ where
                 match value {
                     MaybeCached::Serde(value) => {
                         if serialized_anything && !serialized_anything_serde {
-                            writer.inner_mut().push(',');
+                            writer.inner_mut().push(b',');
                         }
                         serialized_anything = true;
                         serialized_anything_serde = true;
@@ -108,61 +108,46 @@ where
                     },
                     MaybeCached::Cached(Cached::Raw(raw)) => {
                         debug_assert!(
-                            serde_json::to_value(&*raw).is_ok(),
+                            serde_json::from_slice::<serde_json::Value>(raw.as_bytes()).is_ok(),
                             "[json-subscriber] provided cached value is not valid json: {raw}",
                         );
                         let mut writer = writer.inner_mut();
                         if serialized_anything {
-                            writer.push(',');
+                            writer.push(b',');
                         }
                         serialized_anything = true;
-                        writer.push('"');
-                        writer.push_str(key);
-                        writer.push_str("\":");
-                        writer.push_str(&raw);
-                    },
-                    MaybeCached::Cached(Cached::Array(arr)) => {
-                        let mut writer = writer.inner_mut();
-                        if serialized_anything {
-                            writer.push(',');
-                        }
-                        serialized_anything = true;
-                        writer.push('"');
-                        writer.push_str(key);
-                        writer.push_str("\":[");
-                        let mut first = true;
-                        for raw in arr {
-                            debug_assert!(
-                                serde_json::to_value(&*raw).is_ok(),
-                                "[json-subscriber] provided cached value in array is not valid \
-                                 json: {raw}",
-                            );
-                            if !first {
-                                writer.push(',');
-                            }
-                            first = false;
-                            writer.push_str(&raw);
-                        }
-                        writer.push(']');
+                        write_json_key(&mut writer, key)?;
+                        writer.extend_from_slice(raw.as_bytes());
                     },
                     MaybeCached::Raw(raw_fun) => {
                         let mut writer = writer.inner_mut();
                         let rollback_position = writer.len();
                         if serialized_anything {
-                            writer.push(',');
+                            writer.push(b',');
                         }
-                        writer.push('"');
-                        writer.push_str(key);
-                        writer.push_str("\":");
+                        write_json_key(&mut writer, key)?;
                         let start_position = writer.len();
-                        match raw_fun(&event_ref, &mut *writer) {
+                        match raw_fun(&event_ref, &mut writer) {
                             Ok(()) => {
-                                debug_assert!(
-                                    serde_json::to_value(&writer[start_position..]).is_ok(),
-                                    "[json-subscriber] raw value factory created invalid json: {}",
-                                    &writer[start_position..],
-                                );
-                                serialized_anything = true;
+                                if writer.len() == start_position {
+                                    // The factory wrote nothing, meaning it had no value for this
+                                    // event (e.g. no OpenTelemetry context). Roll back the key so
+                                    // the field is omitted entirely instead of serialized as an
+                                    // empty value.
+                                    writer.truncate(rollback_position);
+                                } else {
+                                    debug_assert!(
+                                        serde_json::from_slice::<serde_json::Value>(
+                                            &writer[start_position..],
+                                        )
+                                        .is_ok(),
+                                        "[json-subscriber] raw value factory created invalid \
+                                         json: {}",
+                                        std::str::from_utf8(&writer[start_position..])
+                                            .unwrap_or("<invalid utf8>"),
+                                    );
+                                    serialized_anything = true;
+                                }
                             },
                             Err(error) => {
                                 eprintln!(
@@ -196,7 +181,7 @@ where
                         let map = value.as_object().unwrap();
                         if !map.is_empty() {
                             if serialized_anything && !serialized_anything_serde {
-                                writer.inner_mut().push(',');
+                                writer.inner_mut().push(b',');
                             }
                             serialized_anything = true;
                             serialized_anything_serde = true;
@@ -207,10 +192,10 @@ where
                     },
                     MaybeCached::Cached(Cached::Raw(raw)) => {
                         debug_assert!(
-                            serde_json::to_value(&*raw).is_ok(),
+                            serde_json::from_slice::<serde_json::Value>(raw.as_bytes()).is_ok(),
                             "[json-subscriber] provided cached value is not valid json: {raw}",
                         );
-                        if !raw.contains('\"') {
+                        if !raw.contains('"') {
                             // If the raw string contains at least a single quote, there is at least
                             // one field in the object. Otherwise it is empty and we just skip it.
                             // Assuming it's a valid JSON of course.
@@ -230,40 +215,40 @@ where
                         };
                         let mut writer = writer.inner_mut();
                         if serialized_anything {
-                            writer.push(',');
+                            writer.push(b',');
                         }
                         serialized_anything = true;
-                        writer.push_str(object_contents);
-                    },
-                    MaybeCached::Cached(Cached::Array(_arr)) => {
-                        todo!();
+                        writer.extend_from_slice(object_contents.as_bytes());
                     },
                     MaybeCached::Raw(raw_fun) => {
-                        let mut output = String::new();
+                        let mut output: Vec<u8> = Vec::new();
                         match raw_fun(&event_ref, &mut output) {
                             Ok(()) => {
+                                let Ok(s) = std::str::from_utf8(&output) else {
+                                    eprintln!("[json-subscriber] raw value factory wrote non-utf8");
+                                    continue;
+                                };
                                 debug_assert!(
-                                    serde_json::to_value(&output).is_ok(),
-                                    "[json-subscriber] raw value factory created invalid json: \
-                                     {output}",
+                                    serde_json::from_str::<serde_json::Value>(s).is_ok(),
+                                    "[json-subscriber] raw value factory created invalid json: {s}",
                                 );
-                                let Some(object_contents) = output
+                                let Some(object_contents) = s
                                     .trim()
                                     .strip_prefix('{')
                                     .and_then(|str| str.strip_suffix('}'))
                                 else {
                                     eprintln!(
                                         "[json-subscriber] provided cached value cannot be \
-                                         flattened because it is not an object: {output}"
+                                         flattened because it is not an object: {s}"
                                     );
                                     continue;
                                 };
                                 let mut writer = writer.inner_mut();
                                 if serialized_anything {
-                                    writer.push(',');
+                                    writer.push(b',');
                                 }
                                 serialized_anything = true;
-                                writer.push_str(object_contents);
+                                writer.extend_from_slice(object_contents.as_bytes());
                             },
                             Err(error) => {
                                 eprintln!(
@@ -280,11 +265,12 @@ where
         };
 
         visit().map_err(|_| fmt::Error)?;
-        writer.push('\n');
+        writer.push(b'\n');
 
         debug_assert!(
-            serde_json::to_value(&*writer).is_ok(),
-            "[json-subscriber] serialized line is not valid json: {writer}",
+            serde_json::from_slice::<serde_json::Value>(writer).is_ok(),
+            "[json-subscriber] serialized line is not valid json: {}",
+            std::str::from_utf8(writer).unwrap_or("<invalid utf8>"),
         );
 
         Ok(())
@@ -298,13 +284,11 @@ fn resolve_json_value<'a, S: Subscriber + for<'lookup> LookupSpan<'lookup>>(
     match value {
         JsonValue::Serde(value) => Some(MaybeCached::Serde(Cow::Borrowed(value))),
         JsonValue::DynamicFromEvent(fun) => fun(event).map(Cow::Owned).map(MaybeCached::Serde),
-        JsonValue::DynamicFromSpan(fun) => {
-            event
-                .parent_span()
-                .and_then(fun)
-                .map(Cow::Owned)
-                .map(MaybeCached::Serde)
-        },
+        JsonValue::DynamicFromSpan(fun) => event
+            .parent_span()
+            .and_then(fun)
+            .map(Cow::Owned)
+            .map(MaybeCached::Serde),
         JsonValue::DynamicCachedFromSpan(fun) => {
             event.parent_span().and_then(fun).map(MaybeCached::Cached)
         },
@@ -318,7 +302,5 @@ fn resolve_json_value<'a, S: Subscriber + for<'lookup> LookupSpan<'lookup>>(
 enum MaybeCached<'a, S: for<'lookup> LookupSpan<'lookup>> {
     Serde(Cow<'a, serde_json::Value>),
     Cached(Cached),
-    Raw(
-        &'a Box<dyn Fn(&EventRef<'_, '_, '_, S>, &mut dyn fmt::Write) -> fmt::Result + Send + Sync>,
-    ),
+    Raw(&'a Box<dyn Fn(&EventRef<'_, '_, '_, S>, &mut Vec<u8>) -> fmt::Result + Send + Sync>),
 }

--- a/src/layer/mod.rs
+++ b/src/layer/mod.rs
@@ -1,18 +1,19 @@
 use std::{borrow::Cow, cell::RefCell, collections::BTreeMap, fmt, io, sync::Arc};
 
+// `fmt::Write` is needed for `write!` on `FmtWrite(&mut Vec<u8>)` inside the raw closures.
+use std::fmt::Write;
+
 use serde::Serialize;
 use tracing_core::{
     span::{Attributes, Id, Record},
-    Event,
-    Subscriber,
+    Event, Subscriber,
 };
 use tracing_serde::fields::AsMap;
 use tracing_subscriber::{
     fmt::{format::Writer, time::FormatTime, MakeWriter, TestWriter},
     layer::Context,
     registry::{LookupSpan, SpanRef},
-    Layer,
-    Registry,
+    Layer, Registry,
 };
 
 mod event;
@@ -22,6 +23,7 @@ use uuid::Uuid;
 
 use crate::{
     cached::Cached,
+    cursor::FmtWrite,
     field_writer::FieldWriter,
     fields::{JsonFields, JsonFieldsInner},
     serde::RenamedFields,
@@ -86,7 +88,7 @@ pub(crate) enum JsonValue<S: for<'lookup> LookupSpan<'lookup>> {
     DynamicFromSpan(Box<dyn Fn(&SpanRef<'_, S>) -> Option<serde_json::Value> + Send + Sync>),
     DynamicCachedFromSpan(Box<dyn Fn(&SpanRef<'_, S>) -> Option<Cached> + Send + Sync>),
     DynamicRawFromEvent(
-        Box<dyn Fn(&EventRef<'_, '_, '_, S>, &mut dyn fmt::Write) -> fmt::Result + Send + Sync>,
+        Box<dyn Fn(&EventRef<'_, '_, '_, S>, &mut Vec<u8>) -> fmt::Result + Send + Sync>,
     ),
     DynamicFromEventWithWriter(
         Box<dyn Fn(&EventRef<'_, '_, '_, S>, &mut FieldWriter<'_>) + Send + Sync>,
@@ -156,24 +158,24 @@ where
 
     fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
         thread_local! {
-            static BUF: RefCell<String> = const { RefCell::new(String::new()) };
+            static BUF: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
         }
 
         BUF.with(|buf| {
             let borrow = buf.try_borrow_mut();
             let mut a;
             let mut b;
-            let buf = if let Ok(buf) = borrow {
+            let buf: &mut Vec<u8> = if let Ok(buf) = borrow {
                 a = buf;
-                &mut *a
+                &mut a
             } else {
-                b = String::new();
+                b = Vec::new();
                 &mut b
             };
 
             if self.format_event(&ctx, buf, event).is_ok() {
                 let mut writer = self.make_writer.make_writer_for(event.metadata());
-                let res = io::Write::write_all(&mut writer, buf.as_bytes());
+                let res = io::Write::write_all(&mut writer, buf);
                 if self.log_internal_errors {
                     if let Err(e) = res {
                         eprintln!(
@@ -700,8 +702,12 @@ where
     pub fn with_event(&mut self, key: impl Into<String>) -> &mut Self {
         self.keyed_values.insert(
             SchemaKey::from(key.into()),
-            JsonValue::DynamicFromEvent(Box::new(move |event| {
-                serde_json::to_value(event.field_map()).ok()
+            JsonValue::DynamicRawFromEvent(Box::new(|event, writer: &mut Vec<u8>| {
+                // With the `Vec<u8>` buffer, `serde_json` writes straight into the buffer
+                // (no `Value` tree, no `Cursor`, no per-token UTF-8 check), so this is both
+                // the cleanest and the fastest shape. Key order within the `fields` object
+                // is declaration order (visit order), not alphabetical.
+                serde_json::to_writer(writer, &event.event().field_map()).map_err(|_| fmt::Error)
             })),
         );
         self
@@ -847,17 +853,29 @@ where
     pub fn with_span_list(&mut self, key: impl Into<String>) -> &mut Self {
         self.keyed_values.insert(
             SchemaKey::from(key.into()),
-            JsonValue::DynamicCachedFromSpan(Box::new(|span| {
-                Some(Cached::Array(
-                    span.scope()
-                        .from_root()
-                        .filter_map(|span| {
-                            span.extensions()
-                                .get::<JsonFields>()
-                                .map(|fields| fields.serialized.clone())
-                        })
-                        .collect::<Vec<_>>(),
-                ))
+            JsonValue::DynamicRawFromEvent(Box::new(|event, writer: &mut Vec<u8>| {
+                // Iterate the parent span's scope root→leaf and write each cached
+                // serialized span directly into the buffer as a JSON array. Byte-identical
+                // to the previous `Cached::Array(Vec<Arc<str>>)` path with no per-event
+                // `Vec` allocation.
+                let Some(parent) = event.parent_span() else {
+                    return Ok(());
+                };
+                writer.push(b'[');
+                let mut first = true;
+                for ancestor in parent.scope().from_root() {
+                    let extensions = ancestor.extensions();
+                    let Some(fields) = extensions.get::<JsonFields>() else {
+                        continue;
+                    };
+                    if !first {
+                        writer.push(b',');
+                    }
+                    first = false;
+                    writer.extend_from_slice(fields.serialized.as_bytes());
+                }
+                writer.push(b']');
+                Ok(())
             })),
         );
         self
@@ -907,10 +925,16 @@ where
     ) -> &mut Self {
         self.keyed_values.insert(
             SchemaKey::from(key.into()),
-            JsonValue::DynamicFromEvent(Box::new(move |_| {
-                let mut timestamp = String::with_capacity(32);
-                timer.format_time(&mut Writer::new(&mut timestamp)).ok()?;
-                Some(timestamp.into())
+            JsonValue::DynamicRawFromEvent(Box::new(move |_event, writer: &mut Vec<u8>| {
+                // Write the quoted timestamp straight into the buffer while escaping any
+                // string characters emitted by custom timers.
+                writer.push(b'"');
+                {
+                    let mut writer = EscapedFmtWrite(&mut *writer);
+                    timer.format_time(&mut Writer::new(&mut writer))?;
+                }
+                writer.push(b'"');
+                Ok(())
             })),
         );
         self
@@ -935,10 +959,12 @@ where
     pub fn with_file(&mut self, key: impl Into<String>) -> &mut Self {
         self.keyed_values.insert(
             SchemaKey::from(key.into()),
-            JsonValue::DynamicRawFromEvent(Box::new(|event, writer| {
-                match event.metadata().file() {
-                    Some(file) => write_escaped(writer, file),
-                    None => write!(writer, "null"),
+            JsonValue::DynamicRawFromEvent(Box::new(|event, writer: &mut Vec<u8>| {
+                if let Some(file) = event.metadata().file() {
+                    write_escaped(writer, file)
+                } else {
+                    write_null(writer);
+                    Ok(())
                 }
             })),
         );
@@ -952,10 +978,12 @@ where
     pub fn with_line_number(&mut self, key: impl Into<String>) -> &mut Self {
         self.keyed_values.insert(
             SchemaKey::from(key.into()),
-            JsonValue::DynamicRawFromEvent(Box::new(|event, writer| {
-                match event.metadata().line() {
-                    Some(line) => write!(writer, "{line}"),
-                    None => write!(writer, "null"),
+            JsonValue::DynamicRawFromEvent(Box::new(|event, writer: &mut Vec<u8>| {
+                if let Some(line) = event.metadata().line() {
+                    write!(FmtWrite(&mut *writer), "{line}")
+                } else {
+                    write_null(writer);
+                    Ok(())
                 }
             })),
         );
@@ -980,10 +1008,12 @@ where
     pub fn with_thread_names(&mut self, key: impl Into<String>) -> &mut Self {
         self.keyed_values.insert(
             SchemaKey::from(key.into()),
-            JsonValue::DynamicRawFromEvent(Box::new(|_event, writer| {
-                match std::thread::current().name() {
-                    Some(name) => write_escaped(writer, name),
-                    None => write!(writer, "null"),
+            JsonValue::DynamicRawFromEvent(Box::new(|_event, writer: &mut Vec<u8>| {
+                if let Some(name) = std::thread::current().name() {
+                    write_escaped(writer, name)
+                } else {
+                    write_null(writer);
+                    Ok(())
                 }
             })),
         );
@@ -997,11 +1027,11 @@ where
     pub fn with_thread_ids(&mut self, key: impl Into<String>) -> &mut Self {
         self.keyed_values.insert(
             SchemaKey::from(key.into()),
-            JsonValue::DynamicRawFromEvent(Box::new(|_event, writer| {
-                use std::fmt::Write;
-                let mut value = String::with_capacity(12);
-                write!(&mut value, "{:?}", std::thread::current().id())?;
-                write_escaped(writer, &value)
+            JsonValue::DynamicRawFromEvent(Box::new(|_event, writer: &mut Vec<u8>| {
+                writer.push(b'"');
+                write!(EscapedFmtWrite(writer), "{:?}", std::thread::current().id())?;
+                writer.push(b'"');
+                Ok(())
             })),
         );
 
@@ -1040,55 +1070,68 @@ where
         if display_opentelemetry_ids {
             self.keyed_values.insert(
                 SchemaKey::from("openTelemetry"),
-                JsonValue::DynamicFromSpan(Box::new(|span| {
-                    let mut ids: Option<serde_json::Value> = None;
+                JsonValue::DynamicRawFromEvent(Box::new(|event, writer: &mut Vec<u8>| {
+                    let Some(span) = event.parent_span() else {
+                        return Ok(());
+                    };
+
+                    // On the first feature that yields a valid span context, write
+                    // `{"spanId":"<hex>","traceId":"<hex>"}` straight into the buffer. Both
+                    // `TraceId` and `SpanId` implement `Display` as lowercase zero-padded hex,
+                    // so this skips the `Value::Object` + `BTreeMap` + per-id `String`
+                    // allocations of the previous path. Key order matches the previous
+                    // `BTreeMap`-sorted output (`spanId` before `traceId`).
+                    macro_rules! write_ids {
+                        ($trace_id:expr, $span_id:expr) => {{
+                            return write!(
+                                FmtWrite(&mut *writer),
+                                "{{\"spanId\":\"{}\",\"traceId\":\"{}\"}}",
+                                $span_id,
+                                $trace_id,
+                            );
+                        }};
+                    }
 
                     macro_rules! otel_extraction {
                         ($feature:literal, $tracing_otel_crate:ident, $otel_crate:ident) => {
                             #[cfg(feature = $feature)]
                             {
                                 use $otel_crate::trace::{TraceContextExt, TraceId};
-                                ids = ids.or_else(|| {
-                                    span.extensions()
-                                        .get::<$tracing_otel_crate::OtelData>()
-                                        .and_then(|otel_data| {
-                                            // We should use the parent first if available because
-                                            // we can create a new trace and then change the
-                                            // parent. In that case the value in the builder is not
-                                            // updated.
-                                            let mut trace_id = otel_data
-                                                .parent_cx
-                                                .span()
-                                                .span_context()
-                                                .trace_id();
-                                            if trace_id == TraceId::INVALID {
-                                                trace_id = otel_data.builder.trace_id?;
-                                            }
-                                            let span_id = otel_data.builder.span_id?;
-                                            Some(serde_json::json!({
-                                                "traceId": trace_id.to_string(),
-                                                "spanId": span_id.to_string(),
-                                            }))
-                                        })
-                                });
+                                if let Some(otel_data) =
+                                    span.extensions().get::<$tracing_otel_crate::OtelData>()
+                                {
+                                    // Prefer the parent's trace id: it is possible to create a
+                                    // new trace and then change the parent, in which case the
+                                    // value in the builder is stale.
+                                    let parent_trace_id =
+                                        otel_data.parent_cx.span().span_context().trace_id();
+                                    let trace_id = if parent_trace_id == TraceId::INVALID {
+                                        otel_data.builder.trace_id
+                                    } else {
+                                        Some(parent_trace_id)
+                                    };
+                                    if let (Some(trace_id), Some(span_id)) =
+                                        (trace_id, otel_data.builder.span_id)
+                                    {
+                                        write_ids!(trace_id, span_id);
+                                    }
+                                }
                             }
                         };
                     }
 
                     #[cfg(feature = "tracing-opentelemetry-0-32")]
                     {
-                        ids = ids.or_else(|| {
-                            span.extensions()
-                                .get::<tracing_opentelemetry_0_32::OtelData>()
-                                .and_then(|otel_data| {
-                                    let trace_id = otel_data.trace_id()?;
-                                    let span_id = otel_data.span_id()?;
-                                    Some(serde_json::json!({
-                                        "traceId": trace_id.to_string(),
-                                        "spanId": span_id.to_string(),
-                                    }))
-                                })
-                        });
+                        if let Some(otel_data) = span
+                            .extensions()
+                            .get::<tracing_opentelemetry_0_32::OtelData>()
+                        {
+                            if let (Some(trace_id), Some(span_id)) =
+                                (otel_data.trace_id(), otel_data.span_id())
+                            {
+                                write_ids!(trace_id, span_id);
+                            }
+                        }
                     }
                     otel_extraction!(
                         "tracing-opentelemetry-0-31",
@@ -1116,7 +1159,7 @@ where
                         opentelemetry_0_24
                     );
 
-                    ids
+                    Ok(())
                 })),
             );
         } else {
@@ -1127,31 +1170,65 @@ where
     }
 }
 
-fn write_escaped(writer: &mut dyn fmt::Write, value: &str) -> Result<(), fmt::Error> {
-    let mut rest = value;
-    writer.write_str("\"")?;
-    let mut shift = 0;
-    while let Some(position) = rest
-        .get(shift..)
-        .and_then(|haystack| haystack.find(['\"', '\\']))
-    {
-        let (before, after) = rest.split_at(position + shift);
-        writer.write_str(before)?;
-        writer.write_char('\\')?;
-        rest = after;
-        shift = 1;
+fn write_null(writer: &mut Vec<u8>) {
+    writer.extend_from_slice(b"null");
+}
+
+struct EscapedFmtWrite<'a>(&'a mut Vec<u8>);
+
+impl fmt::Write for EscapedFmtWrite<'_> {
+    fn write_str(&mut self, value: &str) -> fmt::Result {
+        write_escaped_contents(self.0, value)
     }
-    writer.write_str(rest)?;
-    writer.write_str("\"")
+}
+
+fn write_escaped(writer: &mut Vec<u8>, value: &str) -> fmt::Result {
+    writer.push(b'"');
+    write_escaped_contents(writer, value)?;
+    writer.push(b'"');
+    Ok(())
+}
+
+fn write_escaped_contents(writer: &mut Vec<u8>, value: &str) -> fmt::Result {
+    let mut start = 0;
+    for (index, character) in value.char_indices() {
+        let escaped = match character {
+            '"' => Some(b"\\\"".as_slice()),
+            '\\' => Some(b"\\\\".as_slice()),
+            '\n' => Some(b"\\n".as_slice()),
+            '\r' => Some(b"\\r".as_slice()),
+            '\t' => Some(b"\\t".as_slice()),
+            '\u{08}' => Some(b"\\b".as_slice()),
+            '\u{0c}' => Some(b"\\f".as_slice()),
+            '\u{00}'..='\u{1f}' => {
+                writer.extend_from_slice(&value.as_bytes()[start..index]);
+                write!(FmtWrite(writer), "\\u{:04x}", character as u32)?;
+                start = index + character.len_utf8();
+                None
+            },
+            _ => None,
+        };
+
+        if let Some(escaped) = escaped {
+            writer.extend_from_slice(&value.as_bytes()[start..index]);
+            writer.extend_from_slice(escaped);
+            start = index + character.len_utf8();
+        }
+    }
+    writer.extend_from_slice(&value.as_bytes()[start..]);
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, fmt};
 
     use serde_json::json;
     use tracing::subscriber::with_default;
-    use tracing_subscriber::{registry, Layer, Registry};
+    use tracing_subscriber::{
+        fmt::{format::Writer, time::FormatTime},
+        registry, Layer, Registry,
+    };
 
     use super::JsonLayer;
     use crate::tests::MockMakeWriter;
@@ -1237,5 +1314,129 @@ mod tests {
                 "message"
             );
         });
+    }
+
+    #[test]
+    fn raw_event_key_is_json_escaped() {
+        let mut layer = JsonLayer::stdout();
+        layer.with_event("fields\"\\key");
+
+        let expected = json!({
+            "fields\"\\key": {
+                "answer": 42,
+            },
+        });
+
+        test_json(&expected, layer, || {
+            tracing::info!(answer = 42);
+        });
+    }
+
+    struct EscapingTimer;
+
+    impl FormatTime for EscapingTimer {
+        fn format_time(&self, writer: &mut Writer<'_>) -> fmt::Result {
+            writeln!(writer, "bad\\\"time")
+        }
+    }
+
+    #[test]
+    fn timer_output_is_json_escaped() {
+        let mut layer = JsonLayer::stdout();
+        layer.with_timer("timestamp", EscapingTimer);
+
+        let expected = json!({
+            "timestamp": "bad\\\"time\n",
+        });
+
+        test_json(&expected, layer, || {
+            tracing::info!("whatever");
+        });
+    }
+
+    #[test]
+    fn thread_names_escape_json_control_characters() {
+        let actual = std::thread::Builder::new()
+            .name("worker\n1".to_owned())
+            .spawn(|| {
+                let mut layer = JsonLayer::stdout();
+                layer.with_thread_names("threadName");
+
+                produce_log_line(layer, || {
+                    tracing::info!("whatever");
+                })
+            })
+            .unwrap()
+            .join()
+            .unwrap();
+
+        let actual = serde_json::from_str::<serde_json::Value>(&actual).unwrap();
+        assert_eq!(json!({ "threadName": "worker\n1" }), actual);
+    }
+
+    #[cfg(all(
+        feature = "tracing-opentelemetry-0-31",
+        feature = "tracing-opentelemetry-0-30"
+    ))]
+    mod opentelemetry_tests {
+        use tracing::{span::Attributes, Id, Subscriber};
+        use tracing_subscriber::{layer::Context, prelude::*, registry::LookupSpan};
+
+        use super::*;
+
+        struct MixedOtelDataLayer;
+
+        impl<S> Layer<S> for MixedOtelDataLayer
+        where
+            S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+        {
+            fn on_new_span(&self, _attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+                let span = ctx.span(id).unwrap();
+                let mut extensions = span.extensions_mut();
+
+                extensions.insert(tracing_opentelemetry_0_31::OtelData {
+                    parent_cx: opentelemetry_0_30::Context::new(),
+                    builder: opentelemetry_0_30::trace::SpanBuilder::from_name("incomplete"),
+                });
+                extensions.insert(tracing_opentelemetry_0_30::OtelData {
+                    parent_cx: opentelemetry_0_29::Context::new(),
+                    builder: opentelemetry_0_29::trace::SpanBuilder::from_name("complete")
+                        .with_trace_id(opentelemetry_0_29::trace::TraceId::from_bytes([
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+                        ]))
+                        .with_span_id(opentelemetry_0_29::trace::SpanId::from_bytes([
+                            0, 0, 0, 0, 0, 0, 0, 2,
+                        ])),
+                });
+            }
+        }
+
+        #[test]
+        fn opentelemetry_ids_fall_back_after_incomplete_newer_data() {
+            let mut layer = JsonLayer::stdout();
+            layer.with_opentelemetry_ids(true);
+            let make_writer = MockMakeWriter::default();
+            let collector = registry()
+                .with(MixedOtelDataLayer)
+                .with(layer.with_writer(make_writer.clone()));
+
+            with_default(collector, || {
+                let span = tracing::info_span!("span");
+                let _entered = span.enter();
+                tracing::info!("whatever");
+            });
+
+            let buf = make_writer.buf();
+            let actual = serde_json::from_slice::<serde_json::Value>(&buf).unwrap();
+            assert_eq!(
+                json!({
+                    "openTelemetry": {
+                        "spanId": "0000000000000002",
+                        "traceId": "00000000000000000000000000000001",
+                    },
+                }),
+                actual,
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR keeps the public API unchanged while making the default JSON formatting hot path cheaper.

The main change is that event formatting now writes JSON bytes directly into the reusable output
`Vec<u8>` instead of repeatedly building intermediate `serde_json::Value`s or temporary `String`s and
then serializing them again.

## Why this is faster

Before this change, the default `fmt` layer often did work in two phases:

1. build a `serde_json::Value` or temporary string for each event field;
2. serialize that value back into the log line.

The new path writes the final JSON representation once. This avoids several hot-path costs:

- per-event `serde_json::Value` allocation for fields that already know their JSON representation;
- per-event timestamp `String` allocation;
- per-event span-list `Vec<Arc<str>>` allocation;
- extra UTF-8 validation from using `String` as an intermediate buffer;
- copying data from temporary buffers into the final output line.

## Benchmark: `perf-vecu8` vs `main`

Benchmarks were run with the existing `benches/operations.rs` benchmark.

Command shape:

```bash
cargo bench --bench operations -- --sample-size 15 --warm-up-time 1 --measurement-time 3 <filter>
```

| Benchmark | `perf-vecu8` | `main` | current vs main |
|---|---:|---:|---:|
| `event_at_root/no_span_output/100` | 80.612 µs | 159.850 µs | **+98.3%** |
| `event_in_span/current_span/100` | 60.329 µs | 83.894 µs | **+39.1%** |
| `event_in_span/span_list/100` | 66.058 µs | 94.478 µs | **+43.0%** |
| `event_in_span/current_span_and_span_list/100` | 72.081 µs | 99.736 µs | **+38.4%** |
| `event_in_nested_span/current_span_and_span_list/25` | 1.862 µs | 2.872 µs | **+54.3%** |
| `new_span/current_span_and_span_list/100` | 72.809 µs | 70.704 µs | −2.9% |
| `record_value_in_span/current_span_and_span_list/100` | 26.038 µs | 25.820 µs | −0.8% |