### PR TITLE
feat: support tracing-opentelemetry@0.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,7 @@ dependencies = [
  "opentelemetry 0.29.1",
  "opentelemetry 0.30.0",
  "opentelemetry 0.31.0",
+ "opentelemetry 0.32.0",
  "opentelemetry-stdout",
  "opentelemetry_sdk 0.30.0",
  "serde",
@@ -359,6 +360,7 @@ dependencies = [
  "tracing-opentelemetry 0.30.0",
  "tracing-opentelemetry 0.31.0",
  "tracing-opentelemetry 0.32.1",
+ "tracing-opentelemetry 0.33.0",
  "tracing-serde",
  "tracing-subscriber",
  "uuid",
@@ -517,6 +519,19 @@ name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1103,6 +1118,20 @@ checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
  "opentelemetry 0.31.0",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry 0.32.0",
  "tracing",
  "tracing-core",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,10 @@ tracing-opentelemetry-0-32 = [
     "dep:tracing-opentelemetry-0-32",
     "dep:opentelemetry-0-31",
 ]
+tracing-opentelemetry-0-33 = [
+    "dep:tracing-opentelemetry-0-33",
+    "dep:opentelemetry-0-32",
+]
 
 # TODO Remove this for the next breaking release.
 # This is the price I have to pay to the gods of semantic versioning for failing to notice I created
@@ -73,6 +77,8 @@ tracing-opentelemetry-0-31 = { package = "tracing-opentelemetry", version = "0.3
 opentelemetry-0-30 = { package = "opentelemetry", version = "0.30.0", default-features = false, optional = true }
 tracing-opentelemetry-0-32 = { package = "tracing-opentelemetry", version = "0.32.1", default-features = false, optional = true }
 opentelemetry-0-31 = { package = "opentelemetry", version = "0.31.0", default-features = false, optional = true }
+tracing-opentelemetry-0-33 = { package = "tracing-opentelemetry", version = "0.33.0", default-features = false, optional = true }
+opentelemetry-0-32 = { package = "opentelemetry", version = "0.32.0", default-features = false, optional = true }
 
 # OpenTelemetry depends on this but with a version such that minimal versions are broken. We do not use this.
 async-trait = { version = "0.1.9", default-features = false, optional = true }

--- a/src/layer/event.rs
+++ b/src/layer/event.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, fmt, ops::Deref};
 
 use serde::{ser::SerializeMap, Serializer};
-use tracing::{Event, Metadata, Subscriber};
+use tracing::{dispatcher::WeakDispatch, Event, Metadata, Subscriber};
 #[cfg(feature = "tracing-log")]
 use tracing_log::NormalizeEvent;
 use tracing_subscriber::{
@@ -93,7 +93,7 @@ where
             let mut serialized_anything_serde = false;
 
             for (SchemaKey::Static(key), value) in &self.keyed_values {
-                let Some(value) = resolve_json_value(value, &event_ref) else {
+                let Some(value) = resolve_json_value(value, &event_ref, self.dispatch.get()) else {
                     continue;
                 };
 
@@ -187,7 +187,7 @@ where
                     continue;
                 }
 
-                let Some(value) = resolve_json_value(value, &event_ref) else {
+                let Some(value) = resolve_json_value(value, &event_ref, self.dispatch.get()) else {
                     continue;
                 };
 
@@ -294,6 +294,7 @@ where
 fn resolve_json_value<'a, S: Subscriber + for<'lookup> LookupSpan<'lookup>>(
     value: &'a JsonValue<S>,
     event: &EventRef<'_, '_, '_, S>,
+    dispatch: Option<&WeakDispatch>,
 ) -> Option<MaybeCached<'a, S>> {
     match value {
         JsonValue::Serde(value) => Some(MaybeCached::Serde(Cow::Borrowed(value))),
@@ -302,6 +303,14 @@ fn resolve_json_value<'a, S: Subscriber + for<'lookup> LookupSpan<'lookup>>(
             event
                 .parent_span()
                 .and_then(fun)
+                .map(Cow::Owned)
+                .map(MaybeCached::Serde)
+        },
+        JsonValue::DynamicFromSpanWithDispatch(fun) => {
+            event
+                .parent_span()
+                .zip(dispatch.and_then(WeakDispatch::upgrade))
+                .and_then(|(span, dispatch)| fun(span, &dispatch))
                 .map(Cow::Owned)
                 .map(MaybeCached::Serde)
         },

--- a/src/layer/mod.rs
+++ b/src/layer/mod.rs
@@ -1,6 +1,14 @@
-use std::{borrow::Cow, cell::RefCell, collections::BTreeMap, fmt, io, sync::Arc};
+use std::{
+    borrow::Cow,
+    cell::RefCell,
+    collections::BTreeMap,
+    fmt,
+    io,
+    sync::{Arc, OnceLock},
+};
 
 use serde::Serialize;
+use tracing::{dispatcher::WeakDispatch, Dispatch};
 use tracing_core::{
     span::{Attributes, Id, Record},
     Event,
@@ -38,6 +46,7 @@ pub struct JsonLayer<S: for<'lookup> LookupSpan<'lookup> = Registry, W = fn() ->
     log_internal_errors: bool,
     keyed_values: BTreeMap<SchemaKey, JsonValue<S>>,
     flattened_values: BTreeMap<FlatSchemaKey, JsonValue<S>>,
+    dispatch: OnceLock<WeakDispatch>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -84,6 +93,9 @@ pub(crate) enum JsonValue<S: for<'lookup> LookupSpan<'lookup>> {
         Box<dyn Fn(&EventRef<'_, '_, '_, S>) -> Option<serde_json::Value> + Send + Sync>,
     ),
     DynamicFromSpan(Box<dyn Fn(&SpanRef<'_, S>) -> Option<serde_json::Value> + Send + Sync>),
+    DynamicFromSpanWithDispatch(
+        Box<dyn Fn(&SpanRef<'_, S>, &Dispatch) -> Option<serde_json::Value> + Send + Sync>,
+    ),
     DynamicCachedFromSpan(Box<dyn Fn(&SpanRef<'_, S>) -> Option<Cached> + Send + Sync>),
     DynamicRawFromEvent(
         Box<dyn Fn(&EventRef<'_, '_, '_, S>, &mut dyn fmt::Write) -> fmt::Result + Send + Sync>,
@@ -98,6 +110,10 @@ where
     S: Subscriber + for<'lookup> LookupSpan<'lookup>,
     W: for<'writer> MakeWriter<'writer> + 'static,
 {
+    fn on_register_dispatch(&self, subscriber: &tracing::Dispatch) {
+        _ = self.dispatch.set(subscriber.downgrade());
+    }
+
     fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         let Some(span) = ctx.span(id) else {
             if self.log_internal_errors {
@@ -220,6 +236,7 @@ where
             log_internal_errors: false,
             keyed_values: BTreeMap::new(),
             flattened_values: BTreeMap::new(),
+            dispatch: OnceLock::new(),
         }
     }
 }
@@ -252,6 +269,7 @@ where
             log_internal_errors: self.log_internal_errors,
             keyed_values: self.keyed_values,
             flattened_values: self.flattened_values,
+            dispatch: self.dispatch,
         }
     }
 
@@ -315,6 +333,7 @@ where
             log_internal_errors: self.log_internal_errors,
             keyed_values: self.keyed_values,
             flattened_values: self.flattened_values,
+            dispatch: self.dispatch,
         }
     }
 
@@ -360,6 +379,7 @@ where
             log_internal_errors: self.log_internal_errors,
             keyed_values: self.keyed_values,
             flattened_values: self.flattened_values,
+            dispatch: self.dispatch,
         }
     }
 
@@ -1024,6 +1044,7 @@ where
         feature = "tracing-opentelemetry-0-30",
         feature = "tracing-opentelemetry-0-31",
         feature = "tracing-opentelemetry-0-32",
+        feature = "tracing-opentelemetry-0-33",
     ))]
     #[cfg_attr(
         docsrs,
@@ -1034,13 +1055,14 @@ where
             feature = "tracing-opentelemetry-0-30",
             feature = "tracing-opentelemetry-0-31",
             feature = "tracing-opentelemetry-0-32",
+            feature = "tracing-opentelemetry-0-33",
         ))
     )]
     pub fn with_opentelemetry_ids(&mut self, display_opentelemetry_ids: bool) -> &mut Self {
         if display_opentelemetry_ids {
             self.keyed_values.insert(
                 SchemaKey::from("openTelemetry"),
-                JsonValue::DynamicFromSpan(Box::new(|span| {
+                JsonValue::DynamicFromSpanWithDispatch(Box::new(move |span, dispatch| {
                     let mut ids: Option<serde_json::Value> = None;
 
                     macro_rules! otel_extraction {
@@ -1075,6 +1097,21 @@ where
                         };
                     }
 
+                    #[cfg(feature = "tracing-opentelemetry-0-33")]
+                    {
+                        ids = ids.or_else(|| {
+                            tracing_opentelemetry_0_33::get_otel_context(&span.id(), dispatch).map(
+                                |context| {
+                                    use opentelemetry_0_32::trace::TraceContextExt;
+
+                                    serde_json::json!({
+                                        "traceId": context.span().span_context().trace_id().to_string(),
+                                        "spanId": context.span().span_context().span_id().to_string(),
+                                    })
+                                },
+                            )
+                        });
+                    }
                     #[cfg(feature = "tracing-opentelemetry-0-32")]
                     {
                         ids = ids.or_else(|| {


### PR DESCRIPTION
## Motivation

Support `tracing-opentelemetry@0.33` which reworked heavily how trace and span IDs are obtained.

## Solution

We need to save the `Dispatch` which handles the subscriber containing our layer and then use that to obtain the opentelemetry context back out from the `SpanRef` we have.

This is a bit more involved than the previous ways but that's what we need to do here.

The `Dispatch` can maybe later be exposed to user code as they should be able to use `opentelemetry` by themselves and this could also unlock some more use-cases.