### PR TITLE
OpenTelemetry fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,7 @@ dependencies = [
  "opentelemetry 0.31.0",
  "opentelemetry 0.32.0",
  "opentelemetry-stdout",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry_sdk 0.32.1",
  "serde",
  "serde_json",
  "snafu",
@@ -542,13 +542,13 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-stdout"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447191061af41c3943e082ea359ab8b64ff27d6d34d30d327df309ddef1eef6f"
+checksum = "a1b1c6a247d79091f0062a5f4bd058589525cf987a8d4c169440d9c1be72f0ad"
 dependencies = [
  "chrono",
- "opentelemetry 0.30.0",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry 0.32.0",
+ "opentelemetry_sdk 0.32.1",
 ]
 
 [[package]]
@@ -625,7 +625,22 @@ dependencies = [
  "opentelemetry 0.30.0",
  "percent-encoding",
  "rand 0.9.4",
- "serde_json",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.32.0",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
  "thiserror 2.0.11",
 ]
 
@@ -646,6 +661,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "powerfmt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,31 +14,42 @@ repository = "https://github.com/mladedav/json-subscriber"
 default = []
 tracing-log = ["tracing-subscriber/tracing-log", "dep:tracing-log"]
 env-filter = ["tracing-subscriber/env-filter"]
-opentelemetry = ["dep:tracing-opentelemetry-0-25", "dep:opentelemetry-0-24"]
+opentelemetry = [
+    "dep:tracing-opentelemetry-0-25",
+    "dep:opentelemetry-0-24",
+    "__any-tracing-opentelemetry",
+]
 tracing-opentelemetry-0-28 = [
     "dep:tracing-opentelemetry-0-28",
     "dep:opentelemetry-0-27",
+    "__any-tracing-opentelemetry",
 ]
 tracing-opentelemetry-0-29 = [
     "dep:tracing-opentelemetry-0-29",
     "dep:opentelemetry-0-28",
+    "__any-tracing-opentelemetry",
 ]
 tracing-opentelemetry-0-30 = [
     "dep:tracing-opentelemetry-0-30",
     "dep:opentelemetry-0-29",
+    "__any-tracing-opentelemetry",
 ]
 tracing-opentelemetry-0-31 = [
     "dep:tracing-opentelemetry-0-31",
     "dep:opentelemetry-0-30",
+    "__any-tracing-opentelemetry",
 ]
 tracing-opentelemetry-0-32 = [
     "dep:tracing-opentelemetry-0-32",
     "dep:opentelemetry-0-31",
+    "__any-tracing-opentelemetry",
 ]
 tracing-opentelemetry-0-33 = [
     "dep:tracing-opentelemetry-0-33",
     "dep:opentelemetry-0-32",
+    "__any-tracing-opentelemetry",
 ]
+__any-tracing-opentelemetry = []
 
 # TODO Remove this for the next breaking release.
 # This is the price I have to pay to the gods of semantic versioning for failing to notice I created

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,8 +95,8 @@ tracing = { version = "0.1", features = ["attributes"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Used in an example. Should be kept in sync with the latest opentelemetry feature.
-opentelemetry_sdk = { version = "0.30", default-features = false }
-opentelemetry-stdout = "0.30"
+opentelemetry_sdk = { version = "0.32", default-features = false }
+opentelemetry-stdout = "0.32"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/readme-opentelemetry.rs
+++ b/examples/readme-opentelemetry.rs
@@ -1,11 +1,11 @@
 mod yak_shave;
 
-#[cfg(feature = "tracing-opentelemetry-0-31")]
+#[cfg(feature = "tracing-opentelemetry-0-33")]
 fn main() {
     use opentelemetry::trace::TracerProvider;
-    use opentelemetry_0_30 as opentelemetry;
+    use opentelemetry_0_32 as opentelemetry;
     use opentelemetry_sdk;
-    use tracing_opentelemetry_0_31 as tracing_opentelemetry;
+    use tracing_opentelemetry_0_33 as tracing_opentelemetry;
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
     let exporter = opentelemetry_stdout::SpanExporter::default();
@@ -37,7 +37,7 @@ fn main() {
     );
 }
 
-#[cfg(not(feature = "tracing-opentelemetry-0-31"))]
+#[cfg(not(feature = "tracing-opentelemetry-0-33"))]
 fn main() {
-    panic!("This example needs the `tracing-opentelemetry-0-31` feature.");
+    panic!("This example needs the `tracing-opentelemetry-0-33` feature.");
 }

--- a/src/fmt/layer.rs
+++ b/src/fmt/layer.rs
@@ -543,25 +543,8 @@ where
     /// events.
     ///
     /// [OpenTelemetry]: https://opentelemetry.io
-    #[cfg(any(
-        feature = "opentelemetry",
-        feature = "tracing-opentelemetry-0-28",
-        feature = "tracing-opentelemetry-0-29",
-        feature = "tracing-opentelemetry-0-30",
-        feature = "tracing-opentelemetry-0-31",
-        feature = "tracing-opentelemetry-0-32",
-    ))]
-    #[cfg_attr(
-        docsrs,
-        doc(any(
-            feature = "opentelemetry",
-            feature = "tracing-opentelemetry-0-28",
-            feature = "tracing-opentelemetry-0-29",
-            feature = "tracing-opentelemetry-0-30",
-            feature = "tracing-opentelemetry-0-31",
-            feature = "tracing-opentelemetry-0-32",
-        ))
-    )]
+    #[cfg(feature = "__any-tracing-opentelemetry")]
+    #[cfg_attr(docsrs, doc(feature = "__any-tracing-opentelemetry"))]
     #[must_use]
     pub fn with_opentelemetry_ids(mut self, display_opentelemetry_ids: bool) -> Self {
         self.inner.with_opentelemetry_ids(display_opentelemetry_ids);

--- a/src/layer/mod.rs
+++ b/src/layer/mod.rs
@@ -1037,27 +1037,8 @@ where
     /// nothing.
     ///
     /// [OpenTelemetry]: https://opentelemetry.io
-    #[cfg(any(
-        feature = "opentelemetry",
-        feature = "tracing-opentelemetry-0-28",
-        feature = "tracing-opentelemetry-0-29",
-        feature = "tracing-opentelemetry-0-30",
-        feature = "tracing-opentelemetry-0-31",
-        feature = "tracing-opentelemetry-0-32",
-        feature = "tracing-opentelemetry-0-33",
-    ))]
-    #[cfg_attr(
-        docsrs,
-        doc(any(
-            feature = "opentelemetry",
-            feature = "tracing-opentelemetry-0-28",
-            feature = "tracing-opentelemetry-0-29",
-            feature = "tracing-opentelemetry-0-30",
-            feature = "tracing-opentelemetry-0-31",
-            feature = "tracing-opentelemetry-0-32",
-            feature = "tracing-opentelemetry-0-33",
-        ))
-    )]
+    #[cfg(feature = "__any-tracing-opentelemetry")]
+    #[cfg_attr(docsrs, doc(feature = "__any-tracing-opentelemetry"))]
     pub fn with_opentelemetry_ids(&mut self, display_opentelemetry_ids: bool) -> &mut Self {
         if display_opentelemetry_ids {
             self.keyed_values.insert(


### PR DESCRIPTION
This udpates opentelemetry example to use the latest opentelemetry.

It also exposes a method that should have been exposed with the latest feature.